### PR TITLE
Update reminder day in scheduler

### DIFF
--- a/BerichtBotNet/Program.cs
+++ b/BerichtBotNet/Program.cs
@@ -127,7 +127,7 @@ class BerichtBotNet
                 .StartNow()
                 .WithSchedule(CronScheduleBuilder
                     .WeeklyOnDayAndHourAndMinute(
-                        DayOfWeek.Wednesday,
+                        group.ReminderDayOfWeek,
                         group.ReminderTime.ToLocalTime().Hour,
                         group.ReminderTime.ToLocalTime().Minute))
                 .Build();


### PR DESCRIPTION
Modified the weekly report reminder day from a hardcoded "Wednesday" to a dynamic value - `group.ReminderDayOfWeek`. This will allow different groups to set different reminder days according to their requirements, increasing flexibility.